### PR TITLE
[CHANGE] Widget order to `5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Changed
+
+- Widget order priority to 5, so the widget always is below the character widgets that come native with Alliance Auth and can be re-arranged with other priority 5 widgets by changing their app position in the `INSTALLED_APPS` list
+
 ## \[1.0.7\] - 2024-09-22 ([@ppfeufer](https://github.com/ppfeufer))
 
 ### Added

--- a/madashboard/auth_hooks.py
+++ b/madashboard/auth_hooks.py
@@ -11,7 +11,7 @@ from .views import dashboard_memberaudit_check
 
 class MemberCheckDashboardHook(hooks.DashboardItemHook):
     def __init__(self):
-        super().__init__(dashboard_memberaudit_check, 9)
+        super().__init__(view_function=dashboard_memberaudit_check, order=5)
 
 
 @hooks.register("dashboard_hook")


### PR DESCRIPTION
This way it is directly below the native character widgets AA comes with. And can be sorted with other app that have order 5 widgets by arranging the app order in `INSTALLED_APPS` to always stay below the AA character widgets.

![2024-09-23_12-44-47](https://github.com/user-attachments/assets/00781552-ef7a-481b-8f9b-3e89bdac5d82)
