### PR TITLE
[RELEASE] v2.0.0

### DIFF
--- a/madashboard/__init__.py
+++ b/madashboard/__init__.py
@@ -1,6 +1,6 @@
 """Initialize the app"""
 
-__version__ = "1.1.3"
+__version__ = "2.0.0"
 __title__ = "MemberAudit Dashboard"
 
 __package_name__ = "aa-memberaudit-dashboard"

--- a/madashboard/locale/django.pot
+++ b/madashboard/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Member Audit Dashboard 1.1.3\n"
+"Project-Id-Version: AA Member Audit Dashboard \n"
 "Report-Msgid-Bugs-To: https://github.com/Geuthur/aa-memberaudit-dashboard/issues\n"
-"POT-Creation-Date: 2025-10-21 12:18+0200\n"
+"POT-Creation-Date: 2026-05-31 19:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.0.0] - 2026-05-31

> [!IMPORTANT]
>
> This Release needs at least Alliance Auth v5
> Please make sure to update your Alliance Auth before you install this APP

### Added

- Compatibility to Alliance Auth v5